### PR TITLE
Fix pagination of auth zones and missing record view

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,3 +91,4 @@ jobs:
           CI_COMMIT_TIMESTAMP: ${{ github.event.repository.updated_at }}
           CI_COMMIT_SHA: ${{ github.sha }}
           CI_COMMIT_TAG: ${{ needs.release.outputs.tag_name }}
+          REPO_NAME: ${{ github.repository }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,9 +43,9 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
-      - ghcr.io/absaoss/external-dns-infoblox-webhook:latest-amd64
-      - ghcr.io/absaoss/external-dns-infoblox-webhook:{{ .Env.CI_COMMIT_SHA }}-amd64
-      - ghcr.io/absaoss/external-dns-infoblox-webhook:{{ .Env.CI_COMMIT_TAG }}-amd64
+      - ghcr.io/{{ .Env.REPO_NAME }}:latest-amd64
+      - ghcr.io/{{ .Env.REPO_NAME }}:{{ .Env.CI_COMMIT_SHA }}-amd64
+      - ghcr.io/{{ .Env.REPO_NAME }}:{{ .Env.CI_COMMIT_TAG }}-amd64
     build_flag_templates:
       - --pull
       - --platform=linux/amd64
@@ -56,9 +56,9 @@ dockers:
     goos: linux
     goarch: arm64
     image_templates:
-      - ghcr.io/absaoss/external-dns-infoblox-webhook:latest-arm64
-      - ghcr.io/absaoss/external-dns-infoblox-webhook:{{ .Env.CI_COMMIT_SHA }}-arm64
-      - ghcr.io/absaoss/external-dns-infoblox-webhook:{{ .Env.CI_COMMIT_TAG }}-arm64
+      - ghcr.io/{{ .Env.REPO_NAME }}:latest-arm64
+      - ghcr.io/{{ .Env.REPO_NAME }}:{{ .Env.CI_COMMIT_SHA }}-arm64
+      - ghcr.io/{{ .Env.REPO_NAME }}:{{ .Env.CI_COMMIT_TAG }}-arm64
     build_flag_templates:
       - --pull
       - --platform=linux/arm64
@@ -66,18 +66,18 @@ dockers:
       - --build-arg=CI_COMMIT_SHA="{{ .Env.CI_COMMIT_SHA }}"
       - --build-arg=CI_COMMIT_TAG="{{ .Env.CI_COMMIT_TAG }}"
 docker_manifests:
-  - name_template: ghcr.io/absaoss/external-dns-infoblox-webhook:latest
+  - name_template: ghcr.io/{{ .Env.REPO_NAME }}:latest
     image_templates:
-      - ghcr.io/absaoss/external-dns-infoblox-webhook:latest-amd64
-      - ghcr.io/absaoss/external-dns-infoblox-webhook:latest-arm64
-  - name_template: ghcr.io/absaoss/external-dns-infoblox-webhook:{{ .Env.CI_COMMIT_SHA }}
+      - ghcr.io/{{ .Env.REPO_NAME }}:latest-amd64
+      - ghcr.io/{{ .Env.REPO_NAME }}:latest-arm64
+  - name_template: ghcr.io/{{ .Env.REPO_NAME }}:{{ .Env.CI_COMMIT_SHA }}
     image_templates:
-      - ghcr.io/absaoss/external-dns-infoblox-webhook:{{ .Env.CI_COMMIT_SHA }}-amd64
-      - ghcr.io/absaoss/external-dns-infoblox-webhook:{{ .Env.CI_COMMIT_SHA }}-arm64
-  - name_template: ghcr.io/absaoss/external-dns-infoblox-webhook:{{ .Env.CI_COMMIT_TAG }}
+      - ghcr.io/{{ .Env.REPO_NAME }}:{{ .Env.CI_COMMIT_SHA }}-amd64
+      - ghcr.io/{{ .Env.REPO_NAME }}:{{ .Env.CI_COMMIT_SHA }}-arm64
+  - name_template: ghcr.io/{{ .Env.REPO_NAME }}:{{ .Env.CI_COMMIT_TAG }}
     image_templates:
-      - ghcr.io/absaoss/external-dns-infoblox-webhook:{{ .Env.CI_COMMIT_TAG }}-amd64
-      - ghcr.io/absaoss/external-dns-infoblox-webhook:{{ .Env.CI_COMMIT_TAG }}-arm64
+      - ghcr.io/{{ .Env.REPO_NAME }}:{{ .Env.CI_COMMIT_TAG }}-amd64
+      - ghcr.io/{{ .Env.REPO_NAME }}:{{ .Env.CI_COMMIT_TAG }}-arm64
 changelog:
   skip: true
   use: github


### PR DESCRIPTION
This PR has two primary goals.

1. Fetching AuthZones shares the same limitations that fetching records does with respect to # of results returned in a single request (_max_results must be set or infoblox wapi will error if # of results > 1000). Instead of unpredictably misbehaving when # Auth Zone results exceeds INFOBLOX_MAX_RESULTS or relying on huge _max_results, using pagination ensures that all the zones which match the query are fetched.
2. When records are created, the record's view should match its parent zone (or more generally the INFOBLOX_VIEW config option). This fixes https://github.com/AbsaOSS/external-dns-infoblox-webhook/issues/20 which is caused when a record is being created in a different view than its parent zone.

I also added some changes to Gitlab workflows to allow the creation of releases/images in forks. This should make it easier to for contributors to test their changes end-to-end.