### PR TITLE
fix: ptr search query

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ To run the provider, you must provide the following Environment Variables:
 | INFOBLOX_DEFAULT_TTL                | 300           | false    |
 | INFOBLOX_EXTENSIBLE_ATTRIBUTES_JSON | {}            | false    |
 
+### INFOBLOX_CREATE_PTR
+
+When infoblox `INFOBLOX_CREATE_PTR` is set to `true`, make shure that `DOMAIN_FILTER` contains the zone for reversed lookup.
+
+```bash
+DOMAIN_FILTER="cloud.example, 1.2.3.0/24"
+```
 
 **external-dns-infoblox-webhook Environment Variables**:
 


### PR DESCRIPTION
### Issue: PTR Record Lookup Fails

#### Description of the Problem:
The current implementation of the PTR record lookup does not function as expected. An additional field `~=name=<fqdn>` is added to the query deep in the codebase, which causes the PTR record search to be empty. 

**Code Reference:**  
[infoblox.go: line 119](https://github.com/AbsaOSS/external-dns-infoblox-webhook/blob/c92ee6e96b55507b03128cd895e260fc69634277/internal/infoblox/infoblox.go#L119)

#### Current Behavior:
When searching for a PTR record, the following query is generated:

```plaintext
https://infoblox:443/wapi/v2.12/record:ptr?name=new.example.com&name~=new.example.com
```

This query does not return any results because of the additional `name~=` field, which does not align with how PTR records should be queried in Infoblox. And also name contains a reversed ipv4addr.

#### Expected Behavior:
The following query works as expected and returns the correct PTR record:

```plaintext
https://infoblox:443/wapi/v2.12/record:ptr?ptrdname=new.example.com
```

Alternatively, adding an additional search parameter, such as `ipv4addr`, makes the query even more specific and reliable:

```plaintext
https://infoblox:443/wapi/v2.12/record:ptr?ptrdname=new.example.com&ipv4addr=111.222.111.222
```

#### Root Cause:
- The `name` field in the current implementation includes an IP address in reverse order with an additional extension. This must be reversed and handled properly.
- Using `ptrdname` directly is more aligned with Infoblox's API specification for PTR record lookups.
- Adding `ipv4addr` ensures precise matching when searching for a specific record.

Example:

```
    {
        "_ref": "record:ptr/Zay5ubA:222.111.222.111.in-addr.arpa/<view>",
        "extattrs": {},
        "ipv4addr": "111.222.111.222",
        "ipv6addr": "",
        "name": "222.111.222.111.in-addr.arpa",
        "ptrdname": "new.example.com",
        "ttl": 60,
        "use_ttl": true,
        "view": "<view>",
        "zone": "222.111.in-addr.arpa"
    }
```

---

### Proposed Solution:
1. Modify the code to replace the incorrect query logic and remove `name~=` for PTR record lookups.
2. Update the query to use `ptrdname` directly:
   ```plaintext
   https://infoblox:443/wapi/v2.12/record:ptr?ptrdname=new.example.com
   ```
3. For additional precision, optionally include `ipv4addr` in the query:
   ```plaintext
   https://infoblox:443/wapi/v2.12/record:ptr?ptrdname=new.example.com&ipv4addr=111.222.111.222
   ```
---

This pull request aims to improve the accuracy and reliability of PTR record lookups while aligning the implementation with Infoblox API best practices. Feedback is welcome!
