### PR TITLE
fix(infoblox): skip TXT records colliding with a CNAME

### DIFF
--- a/internal/infoblox/infoblox.go
+++ b/internal/infoblox/infoblox.go
@@ -391,7 +391,7 @@ func (p *Provider) submitChanges(changes []*infobloxChange) error {
 	}
 
 	var errs []error
-	changesByZone := p.ChangesByZone(zonePointerConverter(zones), changes)
+	changesByZone := p.ChangesByZone(zonePointerConverter(zones), p.filterConflictingTXTRecords(changes))
 	for zone, changes := range changesByZone {
 		for _, change := range changes {
 			record, err := p.buildRecord(change)
@@ -448,6 +448,71 @@ func (p *Provider) submitChanges(changes []*infobloxChange) error {
 	}
 
 	return nil
+}
+
+// filterConflictingTXTRecords drops TXT records that would be created or updated at an
+// owner name which already holds (or is about to hold) a CNAME record.
+//
+// RFC 1034 3.6.2 and RFC 2181 10.1 forbid a CNAME from coexisting with any other record
+// type at the same owner name, and Infoblox enforces that with a "400 Bad Request".
+// The external-dns TXT registry however still emits the legacy ownership TXT record at
+// the bare owner name in addition to the type-prefixed one ("cname-<name>"), so for every
+// CNAME endpoint one unusable TXT record reaches the provider. The type-prefixed TXT
+// record carries the same ownership information, so skipping the legacy one loses nothing.
+func (p *Provider) filterConflictingTXTRecords(changes []*infobloxChange) []*infobloxChange {
+	// names with a CNAME in this very change set, plus a memo for names looked up remotely
+	hasCNAME := make(map[string]bool)
+	for _, c := range changes {
+		if c.Endpoint.RecordType == endpoint.RecordTypeCNAME && c.Action != infobloxDelete {
+			hasCNAME[strings.ToLower(c.Endpoint.DNSName)] = true
+		}
+	}
+
+	filtered := make([]*infobloxChange, 0, len(changes))
+	for _, c := range changes {
+		if c.Endpoint.RecordType != endpoint.RecordTypeTXT || c.Action == infobloxDelete {
+			filtered = append(filtered, c)
+			continue
+		}
+
+		name := strings.ToLower(c.Endpoint.DNSName)
+		if _, known := hasCNAME[name]; !known {
+			hasCNAME[name] = p.cnameExists(c.Endpoint.DNSName)
+		}
+		if !hasCNAME[name] {
+			filtered = append(filtered, c)
+			continue
+		}
+
+		log.WithFields(log.Fields{
+			"record": c.Endpoint.DNSName,
+			"action": c.Action,
+			"type":   endpoint.RecordTypeTXT,
+		}).Debug("Skipping TXT record, a CNAME record exists at the same name")
+	}
+
+	return filtered
+}
+
+// cnameExists reports whether Infoblox already holds a CNAME record at the given name.
+func (p *Provider) cnameExists(name string) bool {
+	var res []ibclient.RecordCNAME
+	obj := ibclient.NewEmptyRecordCNAME()
+	obj.Name = &name
+
+	startTime := time.Now()
+	err := p.client.GetObject(obj, "", ibclient.NewQueryParams(false, map[string]string{"name": name}), &res)
+	metrics.TotalApiCalls.Inc()
+	metrics.ApiCallLatency.WithLabelValues("GetObjectCNAME").Observe(time.Since(startTime).Seconds())
+	if err != nil {
+		if !isNotFoundError(err) {
+			metrics.FailedApiCallsTotal.Inc()
+			log.WithError(err).Debugf("could not look up CNAME record '%s'", name)
+		}
+		return false
+	}
+
+	return len(res) > 0
 }
 
 func getRefID(record *infobloxRecordSet) (string, log.Fields, error) {

--- a/internal/infoblox/infoblox_test.go
+++ b/internal/infoblox/infoblox_test.go
@@ -945,7 +945,7 @@ func TestInfobloxApplyChanges(t *testing.T) {
 		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeTXT, "tag"),
 		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeCNAME, "other.com"),
 		endpoint.NewEndpoint("zone.example.com", endpoint.RecordTypeNS, "ns-zone.example.com"),
-		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeTXT, "tag"),
+		// no TXT for bar.example.com: a CNAME exists at that name, see issue #23
 		endpoint.NewEndpoint("other.com", endpoint.RecordTypeA, "5.6.7.8"),
 		endpoint.NewEndpoint("other.com", endpoint.RecordTypeTXT, "tag"),
 		endpoint.NewEndpoint("new.example.com", endpoint.RecordTypeA, "111.222.111.222"),
@@ -981,7 +981,7 @@ func TestInfobloxApplyChangesReverse(t *testing.T) {
 		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeTXT, "tag"),
 		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeCNAME, "other.com"),
 		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeNS, "other.com"),
-		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeTXT, "tag"),
+		// no TXT for bar.example.com: a CNAME exists at that name, see issue #23
 		endpoint.NewEndpoint("other.com", endpoint.RecordTypeA, "5.6.7.8"),
 		endpoint.NewEndpoint("other.com", endpoint.RecordTypeTXT, "tag"),
 		endpoint.NewEndpoint("new.example.com", endpoint.RecordTypeA, "111.222.111.222"),
@@ -1094,6 +1094,101 @@ func testInfobloxApplyChangesInternal(t *testing.T, dryRun, createPTR bool, clie
 
 	if err := providerCfg.ApplyChanges(context.Background(), changes); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestInfobloxApplyChangesCNAMEWithTXT covers https://github.com/AbsaOSS/external-dns-infoblox-webhook/issues/23
+//
+// The external-dns TXT registry emits a legacy ownership TXT record at the very same
+// owner name as the record it owns. For a CNAME endpoint that TXT record can never be
+// created, because DNS forbids a CNAME from coexisting with any other record type at
+// the same owner name (RFC 1034 3.6.2, RFC 2181 10.1) and Infoblox rejects it with
+// "400 Bad Request". The type-prefixed TXT record ("cname-<name>") is legal and still
+// carries the ownership information, so it must survive.
+func TestInfobloxApplyChangesCNAMEWithTXT(t *testing.T) {
+	client := mockIBConnector{
+		mockInfobloxZones: &[]ibclient.ZoneAuth{
+			createMockInfobloxZone("example.com"),
+		},
+		mockInfobloxObjects: &[]ibclient.IBObject{},
+	}
+
+	providerCfg := newInfobloxProvider(
+		endpoint.NewDomainFilter([]string{"example.com"}),
+		provider.NewZoneIDFilter([]string{""}),
+		"",
+		false,
+		false,
+		&client,
+	)
+
+	changes := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("cname-test.example.com", endpoint.RecordTypeCNAME, "cname-target.example.com"),
+			// legacy ownership TXT, collides with the CNAME above
+			endpoint.NewEndpoint("cname-test.example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
+			// type-prefixed ownership TXT, legal
+			endpoint.NewEndpoint("cname-cname-test.example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
+		},
+	}
+
+	if err := providerCfg.ApplyChanges(context.Background(), changes); err != nil {
+		t.Fatal(err)
+	}
+
+	validateEndpoints(t, client.createdEndpoints, []*endpoint.Endpoint{
+		endpoint.NewEndpoint("cname-test.example.com", endpoint.RecordTypeCNAME, "cname-target.example.com"),
+		endpoint.NewEndpoint("cname-cname-test.example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
+	})
+
+	for _, ep := range client.createdEndpoints {
+		if ep.RecordType == endpoint.RecordTypeTXT && ep.DNSName == "cname-test.example.com" {
+			t.Errorf("TXT record must not be created at the name of a CNAME record, got: %s", ep)
+		}
+	}
+}
+
+// TestInfobloxApplyChangesCNAMEWithTXTExistingCNAME is the steady-state variant of
+// issue #23: the CNAME was created in an earlier reconciliation loop, so only the
+// colliding legacy TXT record is left in the change set. It must still be skipped.
+func TestInfobloxApplyChangesCNAMEWithTXTExistingCNAME(t *testing.T) {
+	client := mockIBConnector{
+		mockInfobloxZones: &[]ibclient.ZoneAuth{
+			createMockInfobloxZone("example.com"),
+		},
+		mockInfobloxObjects: &[]ibclient.IBObject{
+			createMockInfobloxObjectWithZone("cname-test.example.com", endpoint.RecordTypeCNAME, "cname-target.example.com", "example.com"),
+		},
+	}
+
+	providerCfg := newInfobloxProvider(
+		endpoint.NewDomainFilter([]string{"example.com"}),
+		provider.NewZoneIDFilter([]string{""}),
+		"",
+		false,
+		false,
+		&client,
+	)
+
+	changes := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("cname-test.example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
+			endpoint.NewEndpoint("cname-cname-test.example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
+		},
+	}
+
+	if err := providerCfg.ApplyChanges(context.Background(), changes); err != nil {
+		t.Fatal(err)
+	}
+
+	validateEndpoints(t, client.createdEndpoints, []*endpoint.Endpoint{
+		endpoint.NewEndpoint("cname-cname-test.example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
+	})
+
+	for _, ep := range client.createdEndpoints {
+		if ep.DNSName == "cname-test.example.com" {
+			t.Errorf("TXT record must not be created at the name of an existing CNAME record, got: %s", ep)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #23

## Problem

The external-dns TXT registry emits a legacy ownership TXT record at the bare owner name, in addition to the type-prefixed one (`cname-<name>`). For a CNAME endpoint the legacy TXT record can never be created: DNS forbids a CNAME from coexisting with any other record type at the same owner name (RFC 1034 3.6.2, RFC 2181 10.1), and Infoblox rejects it with `400 Bad Request`. Every CNAME reconciliation logged a `CreateObject request error`.

## Change

`submitChanges` now filters TXT creates and updates whose owner name already holds, or is about to hold, a CNAME record. The type-prefixed TXT record carries the same ownership information and is still created, so no ownership data is lost. Deletes are left untouched so pre-existing records can still be cleaned up. Lookups are memoized per name so at most one extra `record:cname` GET happens per distinct TXT owner name.

## Tests

- `TestInfobloxApplyChangesCNAMEWithTXT`: CNAME and colliding legacy TXT in the same change set.
- `TestInfobloxApplyChangesCNAMEWithTXTExistingCNAME`: steady state, CNAME already on the grid, only the colliding TXT in the change set.

Both were confirmed to fail before the fix and to fail again when the filter call is reverted. `TestInfobloxApplyChanges` and `TestInfobloxApplyChangesReverse` had encoded the buggy behaviour for `bar.example.com` (CNAME plus TXT at the same name); their expectations were corrected.

`go build ./...`, `go vet ./...`, `go test ./... -count=1` and `golangci-lint run ./...` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)