### PR TITLE
feat(config): allow configuring the WAPI base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,27 @@ To run the provider, you must provide the following Environment Variables:
 | INFOBLOX_SSL_VERIFY                 | true          | false    |
 | INFOBLOX_DRY_RUN                    | false         | false    |
 | INFOBLOX_VIEW                       | default       | false    |
+| INFOBLOX_WAPI_BASE_PATH             |               | false    |
 | INFOBLOX_MAX_RESULTS                | 1500          | false    |
 | INFOBLOX_CREATE_PTR                 | false         | false    |
 | INFOBLOX_DEFAULT_TTL                | 300           | false    |
 | INFOBLOX_USE_TTL                    | true          | false    |
 | INFOBLOX_EXTENSIBLE_ATTRIBUTES_JSON | {}            | false    |
+
+### INFOBLOX_WAPI_BASE_PATH
+
+By default all WAPI requests go to `https://<host>:<port>/wapi/v<version>/...`. If the grid is
+reached through a reverse proxy or an API gateway that serves NIOS under an additional path
+prefix, set `INFOBLOX_WAPI_BASE_PATH` to that prefix:
+
+```bash
+# requests become https://<host>:<port>/nios/wapi/v<version>/...
+INFOBLOX_WAPI_BASE_PATH=nios
+```
+
+Nested prefixes are supported (`INFOBLOX_WAPI_BASE_PATH=proxy/nios`). Leading and trailing
+slashes are optional and are stripped. Leaving the variable unset (or setting it to `/` or an
+empty/blank value) keeps the default `/wapi/v<version>` paths unchanged.
 
 ### INFOBLOX_CREATE_PTR
 

--- a/internal/infoblox/infoblox.go
+++ b/internal/infoblox/infoblox.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"strconv"
@@ -70,6 +71,7 @@ type StartupConfig struct {
 	SSLVerify    bool   `name:"infoblox-ssl-verify" env:"INFOBLOX_SSL_VERIFY" default:"true"`
 	DryRun       bool   `name:"infoblox-dry-run" env:"INFOBLOX_DRY_RUN" default:"false"`
 	View         string `name:"infoblox-view" env:"INFOBLOX_VIEW" default:"default"`
+	BasePath     string `name:"infoblox-wapi-base-path" env:"INFOBLOX_WAPI_BASE_PATH" default:""`
 	MaxResults   int    `name:"infoblox-max-results" env:"INFOBLOX_MAX_RESULTS" default:"1500"`
 	CreatePTR    bool   `name:"infoblox-create-ptr" env:"INFOBLOX_CREATE_PTR" default:"false"`
 	DefaultTTL   int    `name:"infoblox-default-ttl" env:"INFOBLOX_DEFAULT_TTL" default:"300"`
@@ -90,6 +92,7 @@ type ExtendedRequestBuilder struct {
 	fqdnRegEx  string
 	nameRegEx  string
 	maxResults int
+	basePath   string
 	ibclient.WapiRequestBuilder
 }
 
@@ -109,10 +112,37 @@ func NewExtendedRequestBuilder(maxResults int, fqdnRegEx string, nameRegEx strin
 	}
 }
 
+// NewExtendedRequestBuilderWithBasePath behaves like NewExtendedRequestBuilder but
+// additionally prefixes every request path with basePath. An empty (or effectively
+// empty) basePath leaves the request path untouched.
+func NewExtendedRequestBuilderWithBasePath(maxResults int, fqdnRegEx, nameRegEx, basePath string) *ExtendedRequestBuilder {
+	rb := NewExtendedRequestBuilder(maxResults, fqdnRegEx, nameRegEx)
+	rb.basePath = normalizeBasePath(basePath)
+	return rb
+}
+
+// normalizeBasePath turns a user supplied WAPI base path into a clean, slash-free
+// prefix. Surrounding whitespace, leading/trailing slashes and empty path segments
+// are dropped, so "/", "  ", "//nios//" and "" all normalize to "" which means
+// "no prefix" and therefore keeps the default upstream behaviour.
+func normalizeBasePath(basePath string) string {
+	segments := make([]string, 0, 2)
+	for _, segment := range strings.Split(basePath, "/") {
+		if segment = strings.TrimSpace(segment); segment != "" {
+			segments = append(segments, segment)
+		}
+	}
+	return strings.Join(segments, "/")
+}
+
 // BuildRequest prepares the api request. it uses BuildRequest of
 // WapiRequestBuilder and then add the _max_requests parameter
 func (mrb *ExtendedRequestBuilder) BuildRequest(t ibclient.RequestType, obj ibclient.IBObject, ref string, queryParams *ibclient.QueryParams) (req *http.Request, err error) {
 	req, err = mrb.WapiRequestBuilder.BuildRequest(t, obj, ref, queryParams)
+	if err != nil {
+		return
+	}
+	mrb.applyBasePath(req)
 	if req.Method == "GET" {
 		query := req.URL.Query()
 		if mrb.maxResults > 0 {
@@ -132,6 +162,41 @@ func (mrb *ExtendedRequestBuilder) BuildRequest(t ibclient.RequestType, obj ibcl
 		req.URL.RawQuery = query.Encode()
 	}
 	return
+}
+
+// applyBasePath prefixes the request path with the configured WAPI base path.
+// It is a no-op when no base path is configured, which keeps the request URL
+// byte-identical to the one produced by the upstream infoblox client.
+func (mrb *ExtendedRequestBuilder) applyBasePath(req *http.Request) {
+	if mrb.basePath == "" || req == nil || req.URL == nil {
+		return
+	}
+	prefix := "/" + (&url.URL{Path: mrb.basePath}).EscapedPath()
+	prefixed, err := url.Parse(prefix + req.URL.EscapedPath())
+	if err != nil {
+		// basePath escaping is done above, so this cannot realistically happen;
+		// fall back to the unprefixed path rather than corrupting the request.
+		log.Warnf("could not apply WAPI base path %q: %v", mrb.basePath, err)
+		return
+	}
+	req.URL.Path = prefixed.Path
+	req.URL.RawPath = prefixed.RawPath
+}
+
+// newRequestBuilder selects the request builder for the given configuration. The
+// extended builder is required as soon as any of _max_results, the FQDN/name regex
+// filters or a custom WAPI base path is configured; otherwise the upstream default
+// builder is used so the request URLs stay byte-identical to previous releases.
+func newRequestBuilder(cfg *StartupConfig, hostCfg ibclient.HostConfig, authCfg ibclient.AuthConfig) (ibclient.HttpRequestBuilder, error) {
+	basePath := normalizeBasePath(cfg.BasePath)
+	if basePath != "" {
+		log.Infof("using custom WAPI base path: /%s/wapi/v%s", basePath, cfg.Version)
+	}
+
+	if cfg.MaxResults != 0 || cfg.FQDNRegEx != "" || cfg.NameRegEx != "" || basePath != "" {
+		return NewExtendedRequestBuilderWithBasePath(cfg.MaxResults, cfg.FQDNRegEx, cfg.NameRegEx, basePath), nil
+	}
+	return ibclient.NewWapiRequestBuilder(hostCfg, authCfg)
 }
 
 // NewInfobloxProvider creates a new Infoblox provider.
@@ -156,19 +221,9 @@ func NewInfobloxProvider(cfg *StartupConfig, domainFilter *endpoint.DomainFilter
 		httpPoolConnections,
 	)
 
-	var (
-		requestBuilder ibclient.HttpRequestBuilder
-		err            error
-	)
-	if cfg.MaxResults != 0 || cfg.FQDNRegEx != "" || cfg.NameRegEx != "" {
-		// use our own HttpRequestBuilder which sets _max_results parameter on GET requests
-		requestBuilder = NewExtendedRequestBuilder(cfg.MaxResults, cfg.FQDNRegEx, cfg.NameRegEx)
-	} else {
-		// use the default HttpRequestBuilder of the infoblox client
-		requestBuilder, err = ibclient.NewWapiRequestBuilder(hostCfg, authCfg)
-		if err != nil {
-			return nil, err
-		}
+	requestBuilder, err := newRequestBuilder(cfg, hostCfg, authCfg)
+	if err != nil {
+		return nil, err
 	}
 
 	requestor := &ibclient.WapiHttpRequestor{}

--- a/internal/infoblox/infoblox_test.go
+++ b/internal/infoblox/infoblox_test.go
@@ -1222,6 +1222,171 @@ func TestExtendedRequestMaxResultsBuilder(t *testing.T) {
 	assert.True(t, req.URL.Query().Get("_max_results") == "")
 }
 
+func TestNormalizeBasePath(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		in       string
+		expected string
+	}{
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"single slash", "/", ""},
+		{"only slashes", "///", ""},
+		{"plain", "nios", "nios"},
+		{"leading slash", "/nios", "nios"},
+		{"trailing slash", "nios/", "nios"},
+		{"both slashes", "/nios/", "nios"},
+		{"nested", "/proxy/nios/", "proxy/nios"},
+		{"duplicate slashes", "//proxy//nios//", "proxy/nios"},
+		{"surrounding whitespace", "  /nios/  ", "nios"},
+		{"whitespace inside segments", "/ proxy / nios /", "proxy/nios"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, normalizeBasePath(tc.in))
+		})
+	}
+}
+
+// TestExtendedRequestBuilderDefaultBasePath pins the default (unconfigured) request
+// path so a regression that unconditionally prefixes requests is caught.
+func TestExtendedRequestBuilderDefaultBasePath(t *testing.T) {
+	hostCfg := ibclient.HostConfig{
+		Host:    "localhost",
+		Port:    "8080",
+		Version: "2.3.1",
+	}
+	authCfg := ibclient.AuthConfig{Username: "user", Password: "abcd"}
+	obj := ibclient.NewEmptyRecordCNAME()
+
+	// the builder without base path support and the one constructed with an
+	// empty/blank base path must produce byte-identical URLs
+	legacy := NewExtendedRequestBuilder(0, "", "")
+	legacy.Init(hostCfg, authCfg)
+	legacyReq, err := legacy.BuildRequest(ibclient.GET, obj, "", &ibclient.QueryParams{})
+	assert.NoError(t, err)
+	assert.Equal(t, "/wapi/v2.3.1/record:cname", legacyReq.URL.Path)
+	assert.Equal(t, "", legacyReq.URL.RawPath)
+
+	for _, basePath := range []string{"", "/", "   ", "//"} {
+		rb := NewExtendedRequestBuilderWithBasePath(0, "", "", basePath)
+		rb.Init(hostCfg, authCfg)
+		req, err := rb.BuildRequest(ibclient.GET, obj, "", &ibclient.QueryParams{})
+		assert.NoError(t, err)
+		assert.Equal(t, legacyReq.URL.String(), req.URL.String(), "base path %q must not change the URL", basePath)
+		assert.Equal(t, "", req.URL.RawPath)
+	}
+}
+
+func TestExtendedRequestBuilderBasePath(t *testing.T) {
+	hostCfg := ibclient.HostConfig{
+		Host:    "localhost",
+		Port:    "8080",
+		Version: "2.3.1",
+	}
+	authCfg := ibclient.AuthConfig{Username: "user", Password: "abcd"}
+
+	for _, tc := range []struct {
+		name         string
+		basePath     string
+		expectedPath string
+	}{
+		{"simple", "nios", "/nios/wapi/v2.3.1/record:cname"},
+		{"leading and trailing slash", "/nios/", "/nios/wapi/v2.3.1/record:cname"},
+		{"nested", "proxy/nios", "/proxy/nios/wapi/v2.3.1/record:cname"},
+		{"duplicate slashes", "//proxy//nios//", "/proxy/nios/wapi/v2.3.1/record:cname"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rb := NewExtendedRequestBuilderWithBasePath(0, "", "", tc.basePath)
+			rb.Init(hostCfg, authCfg)
+
+			obj := ibclient.NewEmptyRecordCNAME()
+			req, err := rb.BuildRequest(ibclient.GET, obj, "", &ibclient.QueryParams{})
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedPath, req.URL.Path)
+			assert.Equal(t, "localhost:8080", req.URL.Host)
+		})
+	}
+}
+
+// TestExtendedRequestBuilderBasePathPreservesQueryAndMethods makes sure prefixing the
+// path does not interfere with the existing _max_results / name~ behaviour.
+func TestExtendedRequestBuilderBasePathPreservesQueryAndMethods(t *testing.T) {
+	hostCfg := ibclient.HostConfig{
+		Host:    "localhost",
+		Port:    "8080",
+		Version: "2.3.1",
+	}
+	authCfg := ibclient.AuthConfig{Username: "user", Password: "abcd"}
+
+	rb := NewExtendedRequestBuilderWithBasePath(54321, "", "^staging.*test.com$", "/nios/")
+	rb.Init(hostCfg, authCfg)
+
+	obj := ibclient.NewEmptyRecordCNAME()
+
+	req, err := rb.BuildRequest(ibclient.GET, obj, "", &ibclient.QueryParams{})
+	assert.NoError(t, err)
+	assert.Equal(t, "/nios/wapi/v2.3.1/record:cname", req.URL.Path)
+	assert.Equal(t, "54321", req.URL.Query().Get("_max_results"))
+	assert.Equal(t, "^staging.*test.com$", req.URL.Query().Get("name~"))
+
+	// non GET requests get the prefix too, but no query parameters
+	req, err = rb.BuildRequest(ibclient.CREATE, obj, "", &ibclient.QueryParams{})
+	assert.NoError(t, err)
+	assert.Equal(t, "/nios/wapi/v2.3.1/record:cname", req.URL.Path)
+	assert.Equal(t, "", req.URL.Query().Get("_max_results"))
+	assert.Equal(t, "", req.URL.Query().Get("name~"))
+
+	// a reference based request (contains characters that need escaping) stays intact
+	ref := "record:cname/ZG5zLmJpbmRfY25hbWUk:foo/bar"
+	req, err = rb.BuildRequest(ibclient.DELETE, obj, ref, &ibclient.QueryParams{})
+	assert.NoError(t, err)
+	assert.Equal(t, "/nios/wapi/v2.3.1/"+ref, req.URL.Path)
+	assert.True(t, strings.HasPrefix(req.URL.EscapedPath(), "/nios/wapi/v2.3.1/"))
+}
+
+// TestNewRequestBuilderBasePathSelectsExtendedBuilder verifies that setting only the
+// base path is enough to activate the extended request builder and that the normalized
+// prefix reaches it, while a blank base path keeps the upstream default builder.
+func TestNewRequestBuilderBasePathSelectsExtendedBuilder(t *testing.T) {
+	base := StartupConfig{
+		Host:     "localhost",
+		Port:     443,
+		Username: "user",
+		Password: "abcd",
+		Version:  "2.3.1",
+		View:     "default",
+	}
+	hostCfg := ibclient.HostConfig{Host: base.Host, Port: "443", Version: base.Version}
+	authCfg := ibclient.AuthConfig{Username: base.Username, Password: base.Password}
+
+	for _, tc := range []struct {
+		name            string
+		basePath        string
+		wantExtended    bool
+		wantBuilderPath string
+	}{
+		{name: "base path only", basePath: "/nios/", wantExtended: true, wantBuilderPath: "nios"},
+		{name: "nested base path", basePath: "proxy//nios", wantExtended: true, wantBuilderPath: "proxy/nios"},
+		{name: "blank base path", basePath: "  //  ", wantExtended: false},
+		{name: "unset base path", basePath: "", wantExtended: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			cfg.BasePath = tc.basePath
+			rb, err := newRequestBuilder(&cfg, hostCfg, authCfg)
+			assert.NoError(t, err)
+
+			extended, ok := rb.(*ExtendedRequestBuilder)
+			if !tc.wantExtended {
+				assert.False(t, ok, "expected the upstream default builder, got %T", rb)
+				return
+			}
+			assert.True(t, ok, "expected *ExtendedRequestBuilder, got %T", rb)
+			assert.Equal(t, tc.wantBuilderPath, extended.basePath)
+		})
+	}
+}
+
 //func TestGetObject(t *testing.T) {
 //	hostCfg := ibclient.HostConfig{}
 //	authCfg := ibclient.AuthConfig{}


### PR DESCRIPTION
Closes #18

## Problem

infoblox-go-client hardcodes the WAPI request path as `/wapi/v<version>/...`. Deployments reaching the grid through a reverse proxy or API gateway that serves NIOS under an extra path prefix cannot be configured.

## Change

Adds `INFOBLOX_WAPI_BASE_PATH`. When set, `ExtendedRequestBuilder` prefixes every request path with the normalized value: `https://<host>:<port>/<prefix>/wapi/v<version>/...`. Nested prefixes work; leading, trailing and duplicate slashes are stripped.

Unset, blank or slash-only leaves the request URL byte-identical to previous releases, and the upstream default request builder is still selected unless another extended-builder option is in use. Builder selection moved into `newRequestBuilder` to make it testable.

`README.md` documents the variable.

## Verification

`go build`, `go vet`, `go test -count=1 ./...` and `golangci-lint` (v2.10.1, matching the pinned workflow version) clean.

3 mutations applied in isolation, all killed:

| Mutation | Tests killed |
|---|---|
| `applyBasePath` made a no-op | `TestExtendedRequestBuilderBasePath/{simple,leading_and_trailing_slash,nested,duplicate_slashes}`, `TestExtendedRequestBuilderBasePathPreservesQueryAndMethods` |
| `basePath != ""` dropped from builder selection | `TestNewRequestBuilderBasePathSelectsExtendedBuilder/base_path_only` |
| `normalizeBasePath` returns input unchanged | `TestNormalizeBasePath` (9 cases) |

The builder-selection mutation initially survived: the test asserted only a non-nil provider, true with either builder. It now asserts the concrete `*ExtendedRequestBuilder` type and the normalized `basePath` field.

Commits are DCO signed off, not GPG-signed.
