### PR TITLE
fix(infoblox): select the most specific reverse zone

### DIFF
--- a/internal/infoblox/infoblox.go
+++ b/internal/infoblox/infoblox.go
@@ -709,10 +709,13 @@ func (p *Provider) findReverseZone(zones []*ibclient.ZoneAuth, name string) *ibc
 			log.WithError(err).Debugf("fqdn %s is no cidr", zone.Fqdn)
 		} else {
 			if rZoneNet.Contains(ip) {
-				_, mask := rZoneNet.Mask.Size()
-				networks[mask] = zones[i]
-				if mask > maxMask {
-					maxMask = mask
+				// Size() returns the prefix length first and the total bit
+				// count second. The prefix length is what makes one reverse
+				// zone more specific than another.
+				prefixLen, _ := rZoneNet.Mask.Size()
+				networks[prefixLen] = zones[i]
+				if prefixLen > maxMask {
+					maxMask = prefixLen
 				}
 			}
 		}

--- a/internal/infoblox/infoblox_test.go
+++ b/internal/infoblox/infoblox_test.go
@@ -1261,3 +1261,26 @@ func (r *mockRequestor) SendRequest(req *http.Request) (res []byte, err error) {
 func validateEndpoints(t *testing.T, endpoints []*endpoint.Endpoint, expected []*endpoint.Endpoint) {
 	assert.True(t, SameEndpoints(endpoints, expected), "actual and expected endpoints don't match. %s:%s", endpoints, expected)
 }
+
+func TestFindReverseZonePicksMostSpecific(t *testing.T) {
+	provider := &Provider{}
+	broad := &ibclient.ZoneAuth{Fqdn: "10.0.0.0/8"}
+	narrow := &ibclient.ZoneAuth{Fqdn: "10.1.2.0/24"}
+
+	// The order must not matter, so try both.
+	assert.Equal(t, narrow, provider.findReverseZone([]*ibclient.ZoneAuth{broad, narrow}, "10.1.2.3"))
+	assert.Equal(t, narrow, provider.findReverseZone([]*ibclient.ZoneAuth{narrow, broad}, "10.1.2.3"))
+
+	// An address outside the narrow zone falls back to the broad one.
+	assert.Equal(t, broad, provider.findReverseZone([]*ibclient.ZoneAuth{broad, narrow}, "10.9.9.9"))
+}
+
+func TestFindReverseZonePicksMostSpecificIPv6(t *testing.T) {
+	provider := &Provider{}
+	broad := &ibclient.ZoneAuth{Fqdn: "2001:db8::/32"}
+	narrow := &ibclient.ZoneAuth{Fqdn: "2001:db8:1::/48"}
+
+	assert.Equal(t, narrow, provider.findReverseZone([]*ibclient.ZoneAuth{broad, narrow}, "2001:db8:1::1"))
+	assert.Equal(t, narrow, provider.findReverseZone([]*ibclient.ZoneAuth{narrow, broad}, "2001:db8:1::1"))
+	assert.Equal(t, broad, provider.findReverseZone([]*ibclient.ZoneAuth{broad, narrow}, "2001:db8:2::1"))
+}


### PR DESCRIPTION
## Problem

`findReverseZone` collects every reverse zone that contains the target address and returns the most specific one. It keys the candidates by mask size:

```go
_, mask := rZoneNet.Mask.Size()
networks[mask] = zones[i]
```

`net.IPMask.Size()` returns `(ones, bits)`. The code reads `bits`, which is 32 for every IPv4 zone and 128 for every IPv6 zone. Every zone of one address family therefore shares a single key, and the map keeps whichever zone appears last in the list.

The selection is not "most specific". It is "last in the list".

## Effect

With `10.0.0.0/8` and `10.1.2.0/24` both configured, a PTR record for `10.1.2.3` can be written to the `/8` zone, depending on the order in which the WAPI returns the zones.

## Change

Read the prefix length instead of the bit count.

## Tests

Two tests, IPv4 and IPv6, each asserting both list orders so the result cannot depend on ordering, plus a case where the address falls outside the narrow zone and must fall back to the broad one.

Both tests fail on `main` and pass with this change.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` and golangci-lint v2.10.1 all pass locally. GoLic reports no missing headers.